### PR TITLE
Add debug output for message extraction

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,27 @@ export class App {
 
       const candidates = this.extractMessages(raw);
 
+      const dbg = document.getElementById('debug');
+      const sample = candidates.slice(0, 3).map(x => ({
+        role: x?.author?.role ?? x?.role,
+        hasParts: Array.isArray(x?.content?.parts),
+        contentType: typeof x?.content
+      }));
+      dbg.hidden = false;
+      dbg.textContent =
+        '[extract] total=' +
+        candidates.length +
+        '  roles=' +
+        JSON.stringify(
+          candidates.reduce((m, x) => {
+            const r = x?.author?.role ?? x?.role ?? 'none';
+            m[r] = (m[r] || 0) + 1;
+            return m;
+          }, {})
+        ) +
+        '\n' +
+        JSON.stringify(sample, null, 2);
+
       const normaliseArray = Parser.normaliseArray ?? Parser.normalizeArray;
       const cleaned = typeof normaliseArray === 'function' ? normaliseArray(candidates) : [];
 

--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
       </div>
     </section>
 
+    <pre id="debug" hidden></pre>
+
     <dialog id="nameOverrideDialog" class="name-dialog" aria-labelledby="nameDialogTitle" aria-describedby="nameDialogDesc" data-dialog="name-overrides" open>
       <form id="nameOverrides" class="control-group" method="dialog" data-form="name-overrides">
         <header class="dialog-header">


### PR DESCRIPTION
## Summary
- add a hidden debug <pre> element beneath the upload controls to host extraction diagnostics
- emit extraction statistics and a sample of parsed messages before normalization in the file import flow

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d33fd99548833085bb7d17e670b81d