### PR TITLE
Improve message extraction for OpenAI exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
       </div>
     </section>
 
+    <pre id="debug" hidden></pre>
+
     <dialog id="nameOverrideDialog" class="name-dialog" aria-labelledby="nameDialogTitle" aria-describedby="nameDialogDesc" data-dialog="name-overrides" open>
       <form id="nameOverrides" class="control-group" method="dialog" data-form="name-overrides">
         <header class="dialog-header">


### PR DESCRIPTION
## Summary
- replace the message extractor with a recursive walker that collects actual message payloads from common OpenAI export shapes
- keep the debug instrumentation and guard it so diagnostics render only when the debug element is present

## Testing
- not run (tests not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d33fd99548833085bb7d17e670b81d