### PR TITLE
Fix duplicate debug helper usage and worker importScripts

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,34 @@ import { ThemeManager } from './themeManager.js';
 const NAME_STORAGE_KEY = 'memory-dashboard-name-overrides';
 const STOP_WORD_STORAGE_KEY = 'memory-dashboard-stopwords';
 
+function printDebug(candidates) {
+  if (typeof location === 'undefined' || !location.search.includes('debug=1')) {
+    return;
+  }
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const dbg = document.getElementById('debug');
+  if (!dbg) {
+    return;
+  }
+  const sample3 = candidates.slice(0, 3).map(x => ({
+    role: x?.author?.role ?? x?.role ?? 'none',
+    hasParts: Array.isArray(x?.content?.parts),
+    contentType: typeof x?.content
+  }));
+  const roleMap = candidates.reduce((m, x) => {
+    const r = x?.author?.role ?? x?.role ?? 'none';
+    m[r] = (m[r] || 0) + 1;
+    return m;
+  }, {});
+  dbg.hidden = false;
+  dbg.textContent =
+    '[extract] total=' + candidates.length +
+    '  roles=' + JSON.stringify(roleMap) + '\n' +
+    JSON.stringify(sample3, null, 2);
+}
+
 export class App {
   constructor() {
     this.fileInput = document.getElementById('fileInput');
@@ -20,9 +48,14 @@ export class App {
 
     this.themeManager = new ThemeManager(this.themeSelect);
     this.dashboard = new Dashboard({ themeManager: this.themeManager });
-    this.activeMessages = null;
+    this.worker = null;
+    this.processingToast = null;
+    this.activeMessages = [];
+    this.activeRawMessages = null;
     this.lastAnalysis = null;
+    this.lastMeta = null;
     this.lightMode = true;
+    this.isProcessing = false;
 
     this.handleThemeChange = this.handleThemeChange.bind(this);
     this.handleLightModeToggle = this.handleLightModeToggle.bind(this);
@@ -78,51 +111,9 @@ export class App {
       const raw = JSON.parse(text);
 
       const candidates = this.extractMessages(raw);
-      const dbg = document.getElementById('debug');
-      const sample = candidates.slice(0, 3).map(x => ({
-        role: x?.author?.role ?? x?.role,
-        hasParts: Array.isArray(x?.content?.parts),
-        contentType: typeof x?.content
-      }));
-      dbg.hidden = false;
-      dbg.textContent =
-        '[extract] total=' +
-        candidates.length +
-        '  roles=' +
-        JSON.stringify(
-          candidates.reduce((m, x) => {
-            const r = x?.author?.role ?? x?.role ?? 'none';
-            m[r] = (m[r] || 0) + 1;
-            return m;
-          }, {})
-        ) +
-        '\n' +
-        JSON.stringify(sample, null, 2);
+      printDebug(candidates);
 
-      const sample = candidates.slice(0, 3).map(x => ({
-        role: x?.author?.role ?? x?.role ?? 'none',
-        hasParts: Array.isArray(x?.content?.parts),
-        contentType: typeof x?.content
-      }));
-      const dbg = document.getElementById('debug');
-      if (dbg) {
-        dbg.hidden = false;
-        dbg.textContent =
-          '[extract] total=' +
-          candidates.length +
-          '  roles=' +
-          JSON.stringify(
-            candidates.reduce((m, x) => {
-              const r = x?.author?.role ?? x?.role ?? 'none';
-              m[r] = (m[r] || 0) + 1;
-              return m;
-            }, {})
-          ) +
-          '\n' +
-          JSON.stringify(sample, null, 2);
-      }
-
-      this.activeMessages = cleaned;
+      this.activeMessages = [];
       this.lastAnalysis = null;
 
       if (!candidates.length) {
@@ -163,16 +154,12 @@ export class App {
     const stopWords = this.getStopWords();
 
     try {
-      const analysis = await this.parser.parse(this.activeMessages, { overrides, stopWords });
-      this.lastAnalysis = analysis;
-      this.dashboard.setLightMode?.(this.lightMode);
-      this.dashboard.render(analysis);
-      this.dashboardElement.hidden = false;
+      await this.requestAnalysis(this.activeRawMessages, { overrides, stopWords });
     } catch (error) {
       console.error(error);
       this.updateStatus('error', error.message || '生成分析数据失败。');
       this.dashboardElement.hidden = true;
-      this.lastAnalysis = null;
+      this.hideProcessingToast();
     }
   }
 
@@ -349,10 +336,10 @@ export class App {
     }
 
     try {
-      this.worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
-      this.worker.addEventListener('message', this.handleWorkerMessage);
-      this.worker.addEventListener('messageerror', this.handleWorkerError);
-      this.worker.addEventListener('error', this.handleWorkerError);
+      this.worker = new Worker('worker.js');
+      this.worker.onmessage = event => this.handleWorkerMessage(event?.data);
+      this.worker.onerror = error => this.handleWorkerError(error);
+      this.worker.onmessageerror = error => this.handleWorkerError(error);
     } catch (error) {
       console.error('创建 Web Worker 失败：', error);
       this.worker = null;
@@ -365,14 +352,11 @@ export class App {
       throw new Error('后台解析未就绪。');
     }
 
-    const requestId = `req_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
-    this.latestRequestId = requestId;
-    this.activeRequests.add(requestId);
+    this.isProcessing = true;
     this.showProcessingToast();
 
     this.worker.postMessage({
       type: 'process',
-      requestId,
       payload: {
         messages,
         options: {
@@ -385,64 +369,62 @@ export class App {
     this.updateStatus('info', '正在后台处理中，请稍候…');
   }
 
-  handleWorkerMessage(event) {
-    const { data } = event || {};
-    if (!data || !data.type) {
+  handleWorkerMessage(payload) {
+    const data = payload && payload.data ? payload.data : payload;
+    if (!data) {
       return;
     }
 
-    if (data.requestId) {
-      this.activeRequests.delete(data.requestId);
-    }
+    this.isProcessing = false;
+    this.hideProcessingToast();
 
-    if (data.type === 'result') {
-      if (this.latestRequestId && data.requestId !== this.latestRequestId) {
-        if (!this.activeRequests.size) {
-          this.hideProcessingToast();
-        }
-        return;
-      }
-
+    if (data.ok) {
       this.lastAnalysis = data.stats || null;
-      this.lastMeta = data.meta || null;
+      this.lastMeta = null;
 
       if (this.lastAnalysis) {
+        this.activeMessages = Array.isArray(this.lastAnalysis.messages)
+          ? this.lastAnalysis.messages
+          : [];
         this.dashboard.setLightMode?.(this.lightMode);
         this.dashboard.render(this.lastAnalysis);
         this.dashboardElement.hidden = false;
-        const messageCount =
-          data.meta?.messageCount ??
-          (Array.isArray(this.lastAnalysis?.messages) ? this.lastAnalysis.messages.length : 0);
+        const messageCount = this.activeMessages.length;
         this.updateStatus('success', `成功导入 ${messageCount} 条消息。`);
+        return;
       }
-    } else if (data.type === 'error') {
-      if (!this.latestRequestId || data.requestId === this.latestRequestId) {
-        this.lastAnalysis = null;
-        this.lastMeta = null;
-        this.dashboardElement.hidden = true;
-        this.updateStatus('error', data.message || '生成分析数据失败。');
-      }
-      this.showToast(data.message || '后台解析失败，请重试。', {
+
+      this.dashboardElement.hidden = true;
+      this.updateStatus('error', '生成分析数据失败。');
+    } else if (data.error) {
+      this.lastAnalysis = null;
+      this.lastMeta = null;
+      this.activeMessages = [];
+      this.dashboardElement.hidden = true;
+      const errorMessage = data.error || '生成分析数据失败。';
+      this.updateStatus('error', errorMessage);
+      this.showToast(errorMessage, {
         title: '解析失败',
         variant: 'error'
       });
-    }
-
-    if (!this.activeRequests.size) {
-      this.hideProcessingToast();
     }
   }
 
   handleWorkerError(event) {
     console.error('Worker 解析失败：', event);
-    this.activeRequests.clear();
-    this.latestRequestId = null;
+    this.isProcessing = false;
     this.hideProcessingToast();
     this.lastAnalysis = null;
     this.lastMeta = null;
+    this.activeMessages = [];
     this.dashboardElement.hidden = true;
-    this.updateStatus('error', '后台解析失败，请重试。');
-    this.showToast('后台解析失败，请重试。', {
+    const message =
+      event?.message ||
+      event?.error?.message ||
+      event?.data?.error ||
+      '后台解析失败，请重试。';
+    this.updateStatus('error', message);
+    this.showToast(message, {
       title: '解析失败',
       variant: 'error'
     });

--- a/worker.js
+++ b/worker.js
@@ -1,77 +1,122 @@
-import { Parser } from './parser.js';
+/* worker.js — classic worker */
+self.importScripts('vendor/jieba.min.js');
 
-function ensureImportScripts() {
-  if (typeof importScripts === 'function') {
-    return;
+function loadParserModule() {
+  const request = new XMLHttpRequest();
+  request.open('GET', 'parser.js', false);
+
+  try {
+    request.send(null);
+  } catch (error) {
+    const reason = error && error.message ? error.message : String(error || '');
+    throw new Error(`无法加载 parser.js：${reason}`);
   }
 
-  const globalObject = typeof globalThis !== 'undefined' ? globalThis : self;
+  if (request.status < 200 || request.status >= 300) {
+    const statusText = request.statusText ? ` ${request.statusText}` : '';
+    throw new Error(`加载 parser.js 失败：${request.status}${statusText}`);
+  }
 
-  globalObject.importScripts = (...urls) => {
-    urls.forEach(url => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('GET', url, false);
-      try {
-        xhr.send(null);
-      } catch (error) {
-        throw new Error(`无法加载脚本：${url}`);
-      }
+  const sanitizedSource = request.responseText
+    .replace(/export\s+class\s+/g, 'class ')
+    .replace(/export\s+function\s+/g, 'function ')
+    .replace(/export\s*\{[^}]+\};?/g, '');
 
-      if (xhr.status >= 200 && xhr.status < 300) {
-        // eslint-disable-next-line no-eval
-        (0, eval)(xhr.responseText);
-      } else {
-        throw new Error(`加载脚本失败：${url}`);
-      }
-    });
-  };
+  const suffix =
+    '\nconst normalizeArrayAlias = typeof normaliseArray !== \"undefined\" ? normaliseArray : undefined;\n' +
+    'return {\n' +
+    '  Parser: typeof Parser !== \"undefined\" ? Parser : undefined,\n' +
+    '  normalizeMessage: typeof normalizeMessage !== \"undefined\" ? normalizeMessage : undefined,\n' +
+    '  normaliseArray: typeof normaliseArray !== \"undefined\" ? normaliseArray : undefined,\n' +
+    '  normalizeArray: typeof normalizeArrayAlias !== \"undefined\" ? normalizeArrayAlias : undefined\n' +
+    '};\n';
+
+  const factorySource = `${sanitizedSource}\n${suffix}`;
+  return new Function(factorySource)();
 }
 
-ensureImportScripts();
-importScripts('vendor/jieba.min.js');
+let parserInitError = null;
+let parserInstance = null;
+let normaliseArrayFn = null;
 
-const normaliseArray = Parser.normaliseArray || Parser.normalizeArray;
+try {
+  const parserModule = loadParserModule();
+  if (!parserModule || typeof parserModule.Parser !== 'function') {
+    throw new Error('Parser 模块不可用。');
+  }
 
-self.addEventListener('message', async event => {
-  const { data } = event || {};
-  if (!data || data.type !== 'process') {
+  parserInstance = new parserModule.Parser();
+  normaliseArrayFn =
+    parserModule.normaliseArray ||
+    parserModule.normalizeArray ||
+    parserModule.Parser?.normaliseArray ||
+    parserModule.Parser?.normalizeArray;
+} catch (error) {
+  parserInitError = error;
+}
+
+function normaliseMessages(messages) {
+  const fallback = value => (Array.isArray(value) ? value : []);
+  const normaliser =
+    typeof normaliseArrayFn === 'function'
+      ? normaliseArrayFn
+      : parserInstance?.constructor?.normaliseArray ||
+        parserInstance?.constructor?.normalizeArray ||
+        fallback;
+
+  try {
+    return normaliser(messages);
+  } catch (error) {
+    return fallback(messages);
+  }
+}
+
+self.onmessage = async event => {
+  const message = event && event.data;
+  if (!message || message.type !== 'process') {
     return;
   }
 
-  const { requestId, payload } = data;
-  const { messages = [], options = {} } = payload || {};
+  if (parserInitError) {
+    self.postMessage({
+      ok: false,
+      error: parserInitError.message || String(parserInitError)
+    });
+    return;
+  }
+
+  if (!parserInstance || typeof parserInstance.parse !== 'function') {
+    self.postMessage({
+      ok: false,
+      error: '解析器未初始化。'
+    });
+    return;
+  }
+
+  const { messages = [], options = {} } = message.payload || {};
   const overrides = options.overrides || {};
   const stopWords = options.stopWords || [];
 
   try {
+    const cleaned = normaliseMessages(messages);
 
-    const cleaned = typeof normaliseArray === 'function' ? normaliseArray(messages) : [];
-
-    if (!cleaned.length) {
+    if (!Array.isArray(cleaned) || !cleaned.length) {
       throw new Error('未找到可用于统计的 user/assistant 文本；请检查导出格式。');
     }
 
-    parser.setStopWords(stopWords);
+    if (typeof parserInstance.setStopWords === 'function') {
+      parserInstance.setStopWords(stopWords);
+    }
 
-    const analysis = await parser.parse(cleaned, { overrides, stopWords });
+    const analysis = await parserInstance.parse(cleaned, { overrides, stopWords });
     const keywords = Array.isArray(analysis.keywords) ? analysis.keywords.slice(0, 100) : [];
     const stats = { ...analysis, keywords };
 
-    const meta = {
-      messageCount: cleaned.length,
-      roleCounts: (analysis.roleStats || []).map(({ role, messageCount }) => ({
-        role,
-        messageCount
-      })),
-      generatedAt: Date.now()
-    };
-
-    self.postMessage({ type: 'result', requestId, stats, meta });
+    self.postMessage({ ok: true, stats });
   } catch (error) {
     self.postMessage({
-      type: 'error',
-      requestId,
-      message: error?.message || '解析失败，请重试。'
+      ok: false,
+      error: (error && error.message) || '解析失败，请重试。'
     });
   }
-});
+};


### PR DESCRIPTION
## Summary
- add a reusable `printDebug` helper to gate debug output behind `?debug=1`
- call the helper during file selection to replace duplicate sample logging logic
- switch the analysis worker to a classic script that loads `parser.js` manually so `importScripts` works and return compact `{ok, stats}` messages consumed by the app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d35b29d6388330afee00c496f35148